### PR TITLE
docs(readme): fix Android Studio icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ Local Environment:
 <a href="https://github.com/tmux/tmux/wiki" target="_blank"><img src="./images/tmux-logo.png" alt="tmux" width="40" height="40" /></a>
 <a href="https://neovim.io/" target="_blank"><img src="./images/neovim-logo.png" alt="neovim" height="40" /></a>
 <a href="https://code.visualstudio.com/" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Visual_Studio_Code_1.35_icon.svg/64px-Visual_Studio_Code_1.35_icon.svg.png" alt="visualstudiocode" width="40" height="40" /></a>
-<a href="https://developer.android.com/studio" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/d/db/Android_Studio_Icon_2021.svg" alt="androidstudio" height="40" /></a>
+<a href="https://developer.android.com/studio" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/3/36/Android_Studio_Icon_2020.svg" alt="androidstudio" height="40" /></a>
 
 <div align="right"><a href="https://www.freepik.com/vectors/travel">Travel vector created by vectorpocket - www.freepik.com</a></div>


### PR DESCRIPTION
Previous link (Android Studio Icon 2021.svg) is not active anymore.
https://commons.wikimedia.org/wiki/File:Android_Studio_Icon_2020.svg

<img width="480px" src="https://user-images.githubusercontent.com/9159773/111120686-f7c7e680-856b-11eb-9236-36c06432a557.png" />

